### PR TITLE
fix reference in angular-scenario.d.ts

### DIFF
--- a/angular-scenario.d.ts
+++ b/angular-scenario.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: RomanoLindano
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="angular.d.ts" />
 
 declare module ng {
     export interface IAngularStatic {


### PR DESCRIPTION
Typescript does not compile because jquery folder does not exist in parent directory. The folder is named dt-jquery. Changed reference to angular.d.ts to follow the convention found in this file's siblings.
